### PR TITLE
updated git repositories

### DIFF
--- a/kernel.conf
+++ b/kernel.conf
@@ -1,10 +1,10 @@
 # kernel.conf - The configuration file for build_kernel.sh
 
 # The Git repository name
-GIT_REPO_NAME=freemangordons-linux-n900
+GIT_REPO_NAME=linux-n900
 
 # The location of the Git repository
-GIT_KERNEL_URI=git://gitorious.org/linux-n900/$GIT_REPO_NAME.git
+GIT_KERNEL_URI=git://github.com/pali/$GIT_REPO_NAME.git
 
 # The branch to check out
 GIT_BRANCH=v3.16-rc1-n900


### PR DESCRIPTION
updated git repositories to use https://github.com/pali/linux-n900 after gitorious shutdown.

http://talk.maemo.org/showthread.php?p=1467576