### PR TITLE
Two small changes

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -27,7 +27,7 @@ done
 test `id -u` -ne 0 || abort "Must not be root"
 
 # Checkout kernel
-test -d $GIT_REPO_NAME && echo "$GIT_REPO_NAME directory already exists.  Skipping cloning of Git repository." || git clone $GIT_KERNEL_URI
+test -d $GIT_REPO_NAME && echo "$GIT_REPO_NAME directory already exists.  Skipping cloning of Git repository." || git clone $GIT_KERNEL_URI --depth $GIT_CLONE_DEPTH
 cd $GIT_REPO_NAME
 git checkout $GIT_BRANCH
 

--- a/kernel.conf
+++ b/kernel.conf
@@ -7,7 +7,7 @@ GIT_REPO_NAME=linux-n900
 GIT_KERNEL_URI=https://github.com/pali/linux-n900.git
 
 # The branch to check out
-GIT_BRANCH=v4.0-rc1-n900
+GIT_BRANCH=v4.6-rc1-n900
 
 # The scheduling priority that will be used to run the build
 NICENESS=0
@@ -33,3 +33,6 @@ ENABLE_OVERLAYFS=y
 
 # Enable rfkill
 ENABLE_RFKILL=y
+
+# Depth of the git clone
+GIT_CLONE_DEPTH=1


### PR DESCRIPTION
Move to kernel 4.6 (default in the pali's repo)
Do a shallow clone (we don't need all the history and the kernel is big)
